### PR TITLE
#1: Add shorthand for CaseEnumSerialization methods (closes #1)

### DIFF
--- a/src/main/scala/macro.scala
+++ b/src/main/scala/macro.scala
@@ -60,6 +60,10 @@ object EnumMacro {
         sealed abstract trait $enumName extends _root_.io.buildo.enumero.CaseEnum
         object ${enumName.toTermName} {
           ..$members
+          def values(implicit ces: _root_.io.buildo.enumero.CaseEnumSerialization[$enumName]): Set[$enumName] = ces.values
+          def caseToString(value: $enumName)(implicit ces: _root_.io.buildo.enumero.CaseEnumSerialization[$enumName]): String = ces.caseToString(value)
+          def caseFromString(str: String)(implicit ces: _root_.io.buildo.enumero.CaseEnumSerialization[$enumName]): Option[$enumName] = ces.caseFromString(str)
+          def name(implicit ces: _root_.io.buildo.enumero.CaseEnumSerialization[$enumName]): String = ces.name
         }
       """)
     }

--- a/src/test/scala/CaseEnumMacroSpec.scala
+++ b/src/test/scala/CaseEnumMacroSpec.scala
@@ -30,6 +30,22 @@ class CaseEnumMacroSpec extends WordSpec with Matchers {
       Beer.Ale should not be a [Beer.Lager.type]
       Beer.Lager shouldBe Beer.Lager
     }
+
+    "allow accessing the values of the enumeration" in {
+      val typecheck: Set[Planet] = Planet.values
+      Planet.values shouldBe Set(Planet.Mercury, Planet.Venus, Planet.Earth)
+    }
+
+    "allow printing / parsing the values of the enumeration" in {
+      Planet.caseFromString("Earth") shouldBe Some(Planet.Earth)
+      Planet.caseFromString("Nope") shouldBe None
+      Planet.caseToString(Planet.Earth) shouldBe "Earth"
+      "Planet.caseToString(Beer.Lager)" shouldNot typeCheck
+    }
+
+    "allow accessing the enumeration name" in {
+      Planet.name shouldBe "Planet"
+    }
   }
 
 }


### PR DESCRIPTION
Closes #1

This change shouldn't be breaking, since it's a syntactic addition and all previous tests still pass.

## Test Plan

### tests performed
unit tests
